### PR TITLE
添加RCU支持

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-sync"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -17,5 +17,5 @@ lockapi = ['lock_api']
 riscv = ["dep:riscv"]
 
 [dev-dependencies]
-# kernel-sync = {path = ".",features = ["riscv"]}
-kernel-sync = {path = "."}
+kernel-sync = {path = ".",features = ["riscv"]}
+# kernel-sync = {path = "."}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ lockapi = ['lock_api']
 riscv = ["dep:riscv"]
 
 [dev-dependencies]
-kernel-sync = {path = ".",features = ["riscv"]}
-
+# kernel-sync = {path = ".",features = ["riscv"]}
+kernel-sync = {path = "."}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kernel-sync
 
-This library is modified from the [spin ](https://github.com/mvdnes/spin-rs)and [kernel-sync]([chyyuu/kernel-sync (gitee.com)](https://gitee.com/chyyuu/kernel-sync)) crates. It adds a new abstract LockAction, allowing kernel implementers to customize the behavior taken when acquiring and releasing locks, such as turning off interrupts and enabling interrupts.
+This library is modified from the [spin ](https://github.com/mvdnes/spin-rs), [kernel-sync]([chyyuu/kernel-sync (gitee.com)](https://gitee.com/chyyuu/kernel-sync)) and [rcu-clean](https://github.com/droundy/rcu-clean) crates. It adds a new abstract LockAction, allowing kernel implementers to customize the behavior taken when acquiring and releasing locks, such as turning off interrupts and enabling interrupts.
 
 ```rust
 /// A trait for lock action
@@ -14,7 +14,7 @@ pub trait LockAction {
 
 ## Features
 
-- `SpinMutex`, `TicketMutex`, `RwLock`
+- `SpinMutex`, `TicketMutex`, `RwLock`, `RcuLock`
 - [`lock_api`](https://crates.io/crates/lock_api) compatibility
 - `LockAction`
 
@@ -27,7 +27,7 @@ kernel-sync = {path = ".",features = ["riscv"]}
 ```
 
 ```rust
-use kernel_sync::{SpinMutex, TicketMutex, RwLock};
+use kernel_sync::{SpinMutex, TicketMutex, RwLock, RcuLock};
 fn main() {
     let x = SpinMutex::new(0);
     *x.lock() = 19;
@@ -38,6 +38,9 @@ fn main() {
     let z = RwLock::new(0);
     *z.write() = 19;
     assert_eq!(*z.read(), 19);
+    let w = RcuLock::new(0);
+    *w.write() = 19;
+    assert_eq!(*w.read(), 19);
 }
 ```
 

--- a/src/arcrcu.rs
+++ b/src/arcrcu.rs
@@ -1,0 +1,173 @@
+﻿use core::cell::{Cell, UnsafeCell};
+use core::{ops, borrow, ptr, mem};
+use core::ptr::null_mut;
+use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+
+/// Based on [droundy/rcu-clean/arcrcu.rs](https://github.com/droundy/rcu-clean) on Github.
+/// 
+/// A thread-safe reference counted pointer that allows interior mutability
+/// 
+/// The [ArcRcu] is functionally roughly equivalent to
+/// `Arc<RwLock<T>>`, except that reads (of the old value) may happen
+/// while a write is taking place.  Reads on an [ArcRcu] are much
+/// faster (by a factor of 2 or 3) than reads on either a
+/// `Arc<RwLock<T>>` or a `Arc<Mutex<T>>`.  So in this case you gain
+/// both ergonomics and read speed.  Writes are slow, so only use this
+/// type if writes are rare (or their speed doesn't matter).
+
+/// ```
+/// let x = rcu_clean::ArcRcu::new(3);
+/// let y: &usize = &(*x);
+/// let z = x.clone();
+/// *x.update() = 7; // Wow, we are mutating something we have borrowed!
+/// assert_eq!(*y, 3); // the old reference is still valid.
+/// assert_eq!(*x, 7); // but the pointer now points to the new value.
+/// assert_eq!(*z, 7); // but the cloned pointer also points to the new value.
+/// ```
+pub struct ArcRcu<T> {
+    inner: Arc<Inner<T>>,
+    have_borrowed: Cell<bool>,
+}
+unsafe impl<T: Send + Sync> Send for ArcRcu<T> {}
+unsafe impl<T: Send + Sync> Sync for ArcRcu<T> {}
+impl<T: Clone> Clone for ArcRcu<T> {
+    fn clone(&self) -> Self {
+        ArcRcu {
+            inner: self.inner.clone(),
+            have_borrowed: Cell::new(false),
+        }
+    }
+}
+pub struct Inner<T> {
+    borrow_count: AtomicUsize,
+    am_writing: AtomicBool,
+    list: List<T>,
+}
+pub struct List<T> {
+    value: UnsafeCell<T>,
+    next: AtomicPtr<List<T>>,
+}
+
+impl<T> ops::Deref for ArcRcu<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        let aleady_borrowed = self.have_borrowed.get();
+        if !aleady_borrowed {
+            self.inner.borrow_count.fetch_add(1, Ordering::Relaxed);
+            self.have_borrowed.set(true); // indicate we have borrowed this once.
+        }
+        let next = self.inner.list.next.load(Ordering::Acquire);
+        if next == null_mut() {
+            unsafe { &*self.inner.list.value.get() }
+        } else {
+            unsafe { &*(*next).value.get() }
+        }
+    }
+}
+impl<T> borrow::Borrow<T> for ArcRcu<T> {
+    fn borrow(&self) -> &T {
+        &*self
+    }
+}
+impl<T> Drop for List<T> {
+    fn drop(&mut self) {
+        let next = self.next.load(Ordering::Acquire);
+        if next != null_mut() {
+            let _free_this = unsafe { Box::from_raw(next) };
+        }
+    }
+}
+impl<'a, T: Clone> ArcRcu<T> {
+    pub fn new(x: T) -> Self {
+        ArcRcu {
+            have_borrowed: Cell::new(false),
+            inner: Arc::new(Inner {
+                borrow_count: AtomicUsize::new(0),
+                am_writing: AtomicBool::new(false),
+                list: List {
+                    value: UnsafeCell::new(x),
+                    next: AtomicPtr::new(null_mut()),
+                },
+            }),
+        }
+    }
+    pub fn try_update(&'a self) -> Option<Guard<'a, T>> {
+        if self.inner.am_writing.swap(true, Ordering::Relaxed) {
+            None
+        }
+        else {
+            Some(Guard {
+                list: Some(List {
+                    value: UnsafeCell::new((*(*self)).clone()),
+                    next: AtomicPtr::new(self.inner.list.next.load(Ordering::Acquire)),
+                }),
+                rc_guts: &self.inner,
+            })
+        }
+    }
+    pub fn clean(&mut self) {
+        let aleady_borrowed = self.have_borrowed.get();
+        if aleady_borrowed {
+            self.inner.borrow_count.fetch_sub(1, Ordering::Relaxed);
+            self.have_borrowed.set(false); // indicate we have no longer borrowed this.
+        }
+        let borrow_count = self.inner.borrow_count.load(Ordering::Relaxed);
+        let next = self.inner.list.next.load(Ordering::Acquire);
+        if borrow_count == 0 && next != null_mut() {
+            unsafe {
+                // make a copy of the old datum that we will need to free
+                let buffer: UnsafeCell<Option<T>> = UnsafeCell::new(None);
+                ptr::copy_nonoverlapping(
+                    self.inner.list.value.get(),
+                    buffer.get() as *mut T,
+                    1,
+                );
+                // now copy the "good" value to the main spot
+                ptr::copy_nonoverlapping((*next).value.get(), self.inner.list.value.get(), 1);
+                // Now we can set the pointer to null which activates
+                // the copy we just made.
+                let _to_be_freed =
+                    Box::from_raw(self.inner.list.next.swap(null_mut(), Ordering::Release));
+                ptr::copy_nonoverlapping(buffer.get() as *mut T, (*next).value.get(), 1);
+                let buffer_copy: UnsafeCell<Option<T>> = UnsafeCell::new(None);
+                ptr::copy_nonoverlapping(buffer_copy.get(), buffer.get(), 1);
+            }
+        }
+    }
+}
+
+pub struct Guard<'a, T: Clone> {
+    list: Option<List<T>>,
+    rc_guts: &'a Inner<T>,
+}
+impl<'a, T: Clone> ops::Deref for Guard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        if let Some(ref list) = self.list {
+            unsafe { &*list.value.get() }
+        } else {
+            unreachable!()
+        }
+    }
+}
+impl<'a, T: Clone> ops::DerefMut for Guard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        if let Some(ref list) = self.list {
+            unsafe { &mut *list.value.get() }
+        } else {
+            unreachable!()
+        }
+    }
+}
+impl<'a, T: Clone> Drop for Guard<'a, T> {
+    fn drop(&mut self) {
+        let list = mem::replace(&mut self.list, None);
+        self.rc_guts
+            .list
+            .next
+            .store(Box::into_raw(Box::new(list.unwrap())), Ordering::Release);
+        self.rc_guts.am_writing.store(false, Ordering::Relaxed);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,10 @@
 extern crate alloc;
 pub mod rwlock;
 
+mod arcrcu;
+pub mod rculock;
+pub use rculock::*;
+
 pub use rwlock::*;
 pub mod ticket;
 pub use ticket::*;
@@ -32,6 +36,11 @@ cfg_if::cfg_if! {
         pub type RwLockReadGuard<'a, T> = crate::rwlock::RwLockReadGuard<'a, T,EmptyLockAction>;
         pub type RwLockWriteGuard<'a, T> = crate::rwlock::RwLockWriteGuard<'a, T,EmptyLockAction>;
         pub type RwLockUpgradableReadGuard<'a, T> = crate::rwlock::RwLockUpgradableGuard<'a, T,EmptyLockAction>;
+
+        // 测试用，之后删除
+        pub type RcuLock<T> = crate::rculock::RcuLock<T, EmptyLockAction, EmptyLockAction>;
+        pub type RcuLockReadGuard<'a, T> = crate::rculock::RcuLockReadGuard<'a, T, EmptyLockAction>;
+        pub type RcuLockWriteGuard<'a, T> = crate::rculock::RcuLockWriteGuard<'a, T, EmptyLockAction>;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//#![no_std]
+#![no_std]
 
 extern crate alloc;
 pub mod rwlock;
@@ -27,6 +27,10 @@ cfg_if::cfg_if! {
         pub type RwLockReadGuard<'a, T> = crate::rwlock::RwLockReadGuard<'a, T,KernelLockAction>;
         pub type RwLockWriteGuard<'a, T> = crate::rwlock::RwLockWriteGuard<'a, T,KernelLockAction>;
         pub type RwLockUpgradableReadGuard<'a, T> = crate::rwlock::RwLockUpgradableGuard<'a, T,KernelLockAction>;
+
+        pub type RcuLock<T> = crate::rculock::RcuLock<T, KernelLockAction>;
+        pub type RcuLockReadGuard<'a, T> = crate::rculock::RcuLockReadGuard<'a, T, KernelLockAction>;
+        pub type RcuLockWriteGuard<'a, T> = crate::rculock::RcuLockWriteGuard<'a, T, KernelLockAction>;
     }else{
         pub type TicketMutex<T> = crate::ticket::TicketMutex<T,EmptyLockAction>;
         pub type TicketMutexGuard<'a, T> = crate::ticket::TicketMutexGuard<'a, T,EmptyLockAction>;
@@ -37,8 +41,7 @@ cfg_if::cfg_if! {
         pub type RwLockWriteGuard<'a, T> = crate::rwlock::RwLockWriteGuard<'a, T,EmptyLockAction>;
         pub type RwLockUpgradableReadGuard<'a, T> = crate::rwlock::RwLockUpgradableGuard<'a, T,EmptyLockAction>;
 
-        // 测试用，之后删除
-        pub type RcuLock<T> = crate::rculock::RcuLock<T, EmptyLockAction, EmptyLockAction>;
+        pub type RcuLock<T> = crate::rculock::RcuLock<T, EmptyLockAction>;
         pub type RcuLockReadGuard<'a, T> = crate::rculock::RcuLockReadGuard<'a, T, EmptyLockAction>;
         pub type RcuLockWriteGuard<'a, T> = crate::rculock::RcuLockWriteGuard<'a, T, EmptyLockAction>;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+//#![no_std]
 
 extern crate alloc;
 pub mod rwlock;

--- a/src/rculock.rs
+++ b/src/rculock.rs
@@ -1,0 +1,137 @@
+﻿//! 基于ArcRcu类型的，和RwLock相似的锁。允许读者和写者同时访问。
+
+use core::{marker::PhantomData, ops::{Deref, DerefMut}};
+
+use alloc::rc::Rc;
+
+use crate::{arcrcu::{ArcRcu, Guard}, LockAction};
+
+/// 对ArcRcu的包装，使得其提供和RwLock相似的接口
+/// R代表读取数据前后，内核需要执行的操作；W代表写入数据前后，内核需要执行的操作
+/// Todo：添加对?Sized的支持
+pub struct RcuLock<T: Clone, R: LockAction, W: LockAction> {
+    phantom_r: PhantomData<R>,
+    phantom_w: PhantomData<W>,
+    rcu: ArcRcu<T>,
+}
+
+unsafe impl<T: Clone + Send + Sync, R: LockAction, W: LockAction> Send for RcuLock<T, R, W> {}
+unsafe impl<T: Clone + Send + Sync, R: LockAction, W: LockAction> Sync for RcuLock<T, R, W> {}
+
+impl<T: Clone, R: LockAction, W: LockAction> Clone for RcuLock<T, R, W> {
+    fn clone(&self) -> Self {
+        Self {
+            phantom_r: PhantomData,
+            phantom_w: PhantomData,
+            rcu: self.rcu.clone()
+        }
+    }
+}
+
+impl<T: Clone, R: LockAction, W: LockAction> RcuLock<T, R, W> {
+    pub fn new(data: T) -> Self {
+        RcuLock { 
+            phantom_r: PhantomData,
+            phantom_w: PhantomData,
+            rcu: ArcRcu::new(data),
+        }
+    }
+
+    /// read必定成功，因此没有try_read
+    pub fn read(&self) -> RcuLockReadGuard<T, R> {
+        R::before_lock();
+        RcuLockReadGuard {
+            phantom: PhantomData,
+            data: &*(self.rcu),
+        }
+    }
+
+    pub fn write(&self) -> RcuLockWriteGuard<T, W> {
+        W::before_lock();
+        loop {
+            match self.rcu.try_update() {
+                Some(guard) => {
+                    return RcuLockWriteGuard {
+                        phantom: PhantomData,
+                        data: guard,
+                        rcu: self.rcu.clone(),
+                    }
+                },
+                None => {
+                    core::hint::spin_loop();
+                }
+            }
+        }
+    }
+
+    pub fn try_write(&self) -> Option<RcuLockWriteGuard<T, W>> {
+        W::before_lock();
+        match self.rcu.try_update() {
+            Some(guard) => {
+                Some(RcuLockWriteGuard {
+                    phantom: PhantomData,
+                    data: guard,
+                    rcu: self.rcu.clone(),
+                })
+            },
+            None => {
+                W::after_lock();
+                None
+            }
+        }
+    }
+}
+
+/// 对读取RCU获得的结构的封装，目前这层封装是为了调用R的方法
+pub struct RcuLockReadGuard<'a, T: Clone, R: LockAction> {
+    phantom: PhantomData<R>,
+    data: &'a T,
+}
+
+impl<'a, T: Clone, R: LockAction> Deref for RcuLockReadGuard<'a, T, R> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.data
+    }
+}
+
+impl<'a, T: Clone, R: LockAction> Drop for RcuLockReadGuard<'a, T, R> {
+    fn drop(&mut self) {
+        R::after_lock();
+    }
+}
+
+pub struct RcuLockWriteGuard<'a, T: Clone, W: LockAction> {
+    phantom: PhantomData<W>,
+    data: Guard<'a, T>,
+    /// 这个Guard所属的RCU
+    rcu: ArcRcu<T>,
+}
+
+impl<'a, T: Clone, W: LockAction> Deref for RcuLockWriteGuard<'a, T, W> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &*(self.data)
+    }
+}
+
+impl<'a, T: Clone, W: LockAction> DerefMut for RcuLockWriteGuard<'a, T, W> {
+
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *(self.data)
+    }
+}
+
+impl<'a, T: Clone, W: LockAction> Drop for RcuLockWriteGuard<'a, T, W> {
+    fn drop(&mut self) {
+        // 调用after_lock函数，等待在此之前的所有读者执行完毕
+        W::after_lock();
+        // 清理之前的版本
+        self.rcu.clean();
+    }
+}
+
+
+

--- a/tests/rculock_test.rs
+++ b/tests/rculock_test.rs
@@ -1,0 +1,104 @@
+﻿extern crate alloc;
+use std::default;
+
+use alloc::sync::Arc;
+use alloc::vec;
+use kernel_sync::RcuLock;
+
+#[test]
+fn basic_test() {
+    let x = RcuLock::new(0);
+    let thread_cnt = 3;
+    // let loop_cnt = 1000000;
+    let loop_cnt = 100;
+    let mut threads = vec![];
+    for _ in 0..thread_cnt {
+        let x_clone = x.clone();
+        threads.push(std::thread::spawn(move || {
+            // let mut guard = x_clone.write();
+            for _ in 0..loop_cnt {
+                let mut guard = x_clone.write();
+                *guard += 1;
+            }
+        }));
+    }
+    for thread in threads {
+        thread.join().unwrap();
+    }
+    assert_eq!(*(x.read()), thread_cnt * loop_cnt);
+}
+
+#[test]
+fn try_lock_test() {
+    let x = RcuLock::new(0);
+    let lock_result0 = x.try_write();
+    assert!(lock_result0.is_some());
+
+    let lock_result1 = x.try_write();
+    assert!(lock_result1.is_none());
+
+    drop(lock_result0);
+
+    let lock_result2 = x.try_write();
+    assert!(lock_result2.is_some());
+}
+
+/// 如果读者和写者不会相互阻塞，大概会看到如下的输出：
+///     running 1 test
+///     thread0 starts.
+///     thread1 starts.
+///     thread2 starts.
+///     read_2 = 0
+///     thread1 ends.
+///     read_3 = 1
+///     thread2 ends.
+///     thread0 ends.
+#[test]
+fn read_write_test() {
+    let x = RcuLock::new(0);
+    let thread_cnt = 3;
+    // let loop_cnt = 1000000;
+    // let loop_cnt = 100;
+    let mut threads = vec![];
+    for i in 0..thread_cnt {
+        let x_clone = x.clone();
+        threads.push(std::thread::spawn(move || {
+            match i {
+                0 => {
+                    std::println!("thread0 starts.");
+                    let read_0 = &*x_clone.read();
+                    assert_eq!(*read_0, 0);
+                    std::thread::sleep(std::time::Duration::from_secs(10));
+                    assert_eq!(*read_0, 0);
+                    std::println!("thread0 ends.");
+                },
+                1 => {
+                    std::println!("thread1 starts.");
+                    std::thread::sleep(std::time::Duration::from_secs(3));
+                    let write_1 = &mut *x_clone.write();
+                    *write_1 = 1;
+                    assert_eq!(*write_1, 1);
+                    std::thread::sleep(std::time::Duration::from_secs(4));
+                    assert_eq!(*write_1, 1);
+                    std::println!("thread1 ends.");
+                },
+                2 => {
+                    std::println!("thread2 starts.");
+                    std::thread::sleep(std::time::Duration::from_secs(5));
+                    let read_2 = &*x_clone.read();
+                    std::println!("read_2 = {read_2}");
+                    std::thread::sleep(std::time::Duration::from_secs(3));
+                    let read_3 = &*x_clone.read();
+                    std::println!("read_3 = {read_3}");
+                    std::println!("thread2 ends.");
+                },
+                _ => {
+
+                }
+            }
+        }));
+    }
+    for thread in threads {
+        thread.join().unwrap();
+    }
+}

--- a/tests/rculock_test.rs
+++ b/tests/rculock_test.rs
@@ -53,40 +53,50 @@ fn read_write_test() {
             match i {
                 0 => {
                     std::println!("thread0 starts.");
-                    let read_0 = &*x_clone.read();
+                    let x = x_clone.read();
+                    let read_0 = &*x;
                     assert_eq!(*read_0, 0);
                     std::thread::sleep(std::time::Duration::from_secs(10));
                     assert_eq!(*read_0, 0);
+                    drop(x);
                     std::println!("thread0 ends.");
                 },
                 1 => {
                     std::println!("thread1 starts.");
                     std::thread::sleep(std::time::Duration::from_secs(3));
-                    let write_1 = &mut *x_clone.write();
+                    let mut x = x_clone.write();
+                    let write_1 = &mut *x;
                     *write_1 = 1;
                     assert_eq!(*write_1, 1);
                     std::thread::sleep(std::time::Duration::from_secs(4));
                     assert_eq!(*write_1, 1);
                     // std::thread::sleep(std::time::Duration::from_secs(4));
+                    drop(x);
                     std::println!("thread1 ends.");
                 },
                 2 => {
                     std::println!("thread2 starts.");
                     std::thread::sleep(std::time::Duration::from_secs(5));
-                    let read_2 = &*x_clone.read();
+                    let x1 = x_clone.read();
+                    let read_2 = &*x1;
                     std::println!("read_2 = {read_2}");
                     std::thread::sleep(std::time::Duration::from_secs(7));
-                    let read_3 = &*x_clone.read();
+                    let x2 = x_clone.read();
+                    let read_3 = &*x2;
                     std::println!("read_3 = {read_3}");
+                    drop(x1);
+                    drop(x2);
                     std::println!("thread2 ends.");
                 },
                 3 => {
                     std::println!("thread3 starts.");
                     std::thread::sleep(std::time::Duration::from_secs(4));
-                    let write_4 = &mut *x_clone.write();
+                    let mut x = x_clone.write();
+                    let write_4 = &mut *x;
                     *write_4 += 1;
                     assert_eq!(*write_4, 2);
                     // std::thread::sleep(std::time::Duration::from_secs(6));
+                    drop(x);
                     std::println!("thread3 ends.");
                 },
                 _ => {},

--- a/tests/rculock_test.rs
+++ b/tests/rculock_test.rs
@@ -1,7 +1,4 @@
 ﻿extern crate alloc;
-use std::default;
-
-use alloc::sync::Arc;
 use alloc::vec;
 use kernel_sync::RcuLock;
 
@@ -9,8 +6,8 @@ use kernel_sync::RcuLock;
 fn basic_test() {
     let x = RcuLock::new(0);
     let thread_cnt = 3;
-    // let loop_cnt = 1000000;
-    let loop_cnt = 100;
+    let loop_cnt = 1000000;
+    // let loop_cnt = 100;
     let mut threads = vec![];
     for _ in 0..thread_cnt {
         let x_clone = x.clone();
@@ -43,20 +40,10 @@ fn try_lock_test() {
     assert!(lock_result2.is_some());
 }
 
-/// 如果读者和写者不会相互阻塞，大概会看到如下的输出：
-///     running 1 test
-///     thread0 starts.
-///     thread1 starts.
-///     thread2 starts.
-///     read_2 = 0
-///     thread1 ends.
-///     read_3 = 1
-///     thread2 ends.
-///     thread0 ends.
 #[test]
 fn read_write_test() {
     let x = RcuLock::new(0);
-    let thread_cnt = 3;
+    let thread_cnt = 4;
     // let loop_cnt = 1000000;
     // let loop_cnt = 100;
     let mut threads = vec![];
@@ -80,6 +67,7 @@ fn read_write_test() {
                     assert_eq!(*write_1, 1);
                     std::thread::sleep(std::time::Duration::from_secs(4));
                     assert_eq!(*write_1, 1);
+                    // std::thread::sleep(std::time::Duration::from_secs(4));
                     std::println!("thread1 ends.");
                 },
                 2 => {
@@ -87,14 +75,21 @@ fn read_write_test() {
                     std::thread::sleep(std::time::Duration::from_secs(5));
                     let read_2 = &*x_clone.read();
                     std::println!("read_2 = {read_2}");
-                    std::thread::sleep(std::time::Duration::from_secs(3));
+                    std::thread::sleep(std::time::Duration::from_secs(7));
                     let read_3 = &*x_clone.read();
                     std::println!("read_3 = {read_3}");
                     std::println!("thread2 ends.");
                 },
-                _ => {
-
-                }
+                3 => {
+                    std::println!("thread3 starts.");
+                    std::thread::sleep(std::time::Duration::from_secs(4));
+                    let write_4 = &mut *x_clone.write();
+                    *write_4 += 1;
+                    assert_eq!(*write_4, 2);
+                    // std::thread::sleep(std::time::Duration::from_secs(6));
+                    std::println!("thread3 ends.");
+                },
+                _ => {},
             }
         }));
     }

--- a/tests/rculock_test.rs
+++ b/tests/rculock_test.rs
@@ -70,7 +70,6 @@ fn read_write_test() {
                     assert_eq!(*write_1, 1);
                     std::thread::sleep(std::time::Duration::from_secs(4));
                     assert_eq!(*write_1, 1);
-                    // std::thread::sleep(std::time::Duration::from_secs(4));
                     drop(x);
                     std::println!("thread1 ends.");
                 },
@@ -95,7 +94,6 @@ fn read_write_test() {
                     let write_4 = &mut *x;
                     *write_4 += 1;
                     assert_eq!(*write_4, 2);
-                    // std::thread::sleep(std::time::Duration::from_secs(6));
                     drop(x);
                     std::println!("thread3 ends.");
                 },


### PR DESCRIPTION
基于[rcu-clean](https://github.com/droundy/rcu-clean)，为该项目增加了`RcuLock`结构，并可以在`no_std`环境下使用。
其具有与`RwLock`类似的接口，并且使读者和写者可以同时访问。
